### PR TITLE
Fix version number.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='Products.ZCTextIndex',
       ],
       install_requires=[
           'setuptools',
-          'Products.ZCatalog >= 4.0.a2',
+          'Products.ZCatalog >= 4.0a2',
       ],
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
According to https://www.python.org/dev/peps/pep-0440/#pre-releases there should be no dot before the `a`.
While installing version 4.0 tox did not load a new version of ZCatalog.
